### PR TITLE
Add new technical blog sections and guides

### DIFF
--- a/content/posts/comunicaciones/_index.en.md
+++ b/content/posts/comunicaciones/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: Communications
+menu:
+  sidebar:
+    name: Communications
+    identifier: communications
+    weight: 3
+---

--- a/content/posts/comunicaciones/_index.md
+++ b/content/posts/comunicaciones/_index.md
@@ -1,0 +1,8 @@
+---
+title: Comunicaciones
+menu:
+  sidebar:
+    name: Comunicaciones
+    identifier: comunicaciones
+    weight: 3
+---

--- a/content/posts/comunicaciones/meshtastic/index.md
+++ b/content/posts/comunicaciones/meshtastic/index.md
@@ -1,0 +1,77 @@
+---
+title: "Meshtastic explicado"
+date: 2024-03-16T12:30:00+02:00
+description: "Cómo funciona Meshtastic, hardware compatible y casos de uso para redes LoRa de largo alcance."
+menu:
+  sidebar:
+    name: Meshtastic explicado
+    identifier: meshtastic
+    parent: comunicaciones
+    weight: 1
+hero: images/meshtastic-cover.jpg
+tags:
+- LoRa
+- Mesh networks
+- Comunicaciones
+- IoT
+categories:
+- Comunicaciones
+- IoT
+---
+
+**Meshtastic** es un firmware open source que transforma radios LoRa de bajo costo en redes malladas para mensajería y telemetría sin infraestructura celular. Es ideal para actividades al aire libre, resiliencia ante desastres y proyectos comunitarios.
+
+---
+
+## Arquitectura básica
+
+- **Radios LoRa** basados en chip SX1262/SX1276 que operan en bandas ISM (433, 868, 915 MHz).
+- **Firmware Meshtastic** sobre microcontroladores ESP32, nRF52 o RP2040.
+- **Topología mesh**: cada nodo reenvía mensajes de manera asincrónica usando enrutamiento oportunista.
+- **Aplicaciones móviles** (Android/iOS) y clientes CLI/desktop que se conectan vía Bluetooth o USB.
+
+---
+
+## Tipos de nodos
+
+1. **Nodos personales:** dispositivos portátiles con pantalla (LilyGO T-Beam, T-Echo) que envían textos y ubicación GPS.
+2. **Nodos de infraestructura:** placas alimentadas continuamente para ampliar cobertura (antenas externas, alta potencia).
+3. **Nodos sensores:** integran telemetría (temperatura, humedad, relés) y reportan periódicamente.
+
+---
+
+## Configuración inicial
+
+1. Instala el firmware con **Meshtastic Flasher** o `meshtastic --flash`.
+2. Empareja el dispositivo con la app móvil mediante Bluetooth o USB.
+3. Ajusta **canal, región y potencia** según normativa local (duty cycle, ERP).
+4. Define roles (router, client) y habilita características como MQTT bridge o almacenamiento en tarjeta SD.
+
+---
+
+## Funciones destacadas
+
+- **Mensajería encriptada** con AES-CTR y claves compartidas.
+- **Posicionamiento GPS** y compartición de coordenadas con iconos personalizados.
+- **Bridge MQTT/HTTP** para integrar con servidores o dashboards remotos.
+- **Telemetría extendida** a través de plugins Python (`meshtastic-python`).
+
+---
+
+## Casos de uso
+
+- Equipos de senderismo, ciclismo o rescate que requieren comunicación sin cobertura celular.
+- Redes comunitarias de alerta temprana (incendios, inundaciones).
+- IoT rural con nodos alimentados por energía solar.
+- Eventos temporales donde se necesita mensajería descentralizada.
+
+---
+
+## Buenas prácticas
+
+1. Utiliza **antenas calibradas** y respeta la polarización para maximizar alcance.
+2. Configura **intervalos de retransmisión** adecuados para evitar congestión en mallas densas.
+3. Documenta **claves y canales** en un gestor seguro para tu equipo.
+4. Mantén el firmware actualizado y participa en la comunidad de GitHub/Discord para aprovechar nuevas funciones.
+
+Con esta visión podrás planear una red Meshtastic confiable y adaptarla a tus necesidades de comunicación de largo alcance.

--- a/content/posts/comunicaciones/mqtt-esp32/index.md
+++ b/content/posts/comunicaciones/mqtt-esp32/index.md
@@ -1,0 +1,122 @@
+---
+title: "Controlar un LED con ESP32 y MQTT"
+date: 2024-03-16T19:30:00+02:00
+description: "Tutorial para controlar un LED desde un broker MQTT local o remoto usando ESP32 y un VPS."
+menu:
+  sidebar:
+    name: Controlar un LED con ESP32 y MQTT
+    identifier: mqtt-esp32
+    parent: comunicaciones
+    weight: 2
+hero: images/mqtt-esp32-cover.jpg
+tags:
+- MQTT
+- ESP32
+- IoT
+- Domótica
+categories:
+- Comunicaciones
+- IoT
+---
+
+MQTT es un protocolo ligero de mensajería ideal para IoT. Con un ESP32 y un broker local o en un VPS puedes controlar actuadores desde cualquier lugar del mundo.
+
+---
+
+## Preparar el broker
+
+### Opción local (Mosquitto)
+
+```bash
+sudo apt update
+sudo apt install mosquitto mosquitto-clients
+sudo systemctl enable --now mosquitto
+```
+
+### Opción VPS
+
+1. Contrata un VPS ligero (1 vCPU, 1 GB RAM).
+2. Instala Mosquitto y configura autenticación básica en `/etc/mosquitto/conf.d/seguro.conf`:
+
+```
+allow_anonymous false
+password_file /etc/mosquitto/passwd
+listener 8883
+cafile /etc/letsencrypt/live/tu-dominio/fullchain.pem
+keyfile /etc/letsencrypt/live/tu-dominio/privkey.pem
+certfile /etc/letsencrypt/live/tu-dominio/fullchain.pem
+```
+
+3. Genera certificados TLS con Let’s Encrypt y crea usuarios con `mosquitto_passwd`.
+
+---
+
+## Firmware ESP32 (Arduino core)
+
+```cpp
+#include <WiFi.h>
+#include <PubSubClient.h>
+
+const char* ssid = "TuRed";
+const char* password = "TuClave";
+const char* mqtt_server = "broker.tudominio.com";
+const int mqtt_port = 8883;
+
+WiFiClientSecure espClient;
+PubSubClient client(espClient);
+const int ledPin = 2;
+
+void callback(char* topic, byte* payload, unsigned int length) {
+  String mensaje;
+  for (unsigned int i = 0; i < length; i++) mensaje += (char)payload[i];
+  digitalWrite(ledPin, mensaje == "ON" ? HIGH : LOW);
+}
+
+void reconnect() {
+  while (!client.connected()) {
+    if (client.connect("esp32-led", "usuario", "password")) {
+      client.subscribe("casa/sala/led");
+    } else {
+      delay(2000);
+    }
+  }
+}
+
+void setup() {
+  pinMode(ledPin, OUTPUT);
+  Serial.begin(115200);
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+  }
+  espClient.setCACert("-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----\n");
+  client.setServer(mqtt_server, mqtt_port);
+  client.setCallback(callback);
+}
+
+void loop() {
+  if (!client.connected()) reconnect();
+  client.loop();
+}
+```
+
+Para conexiones sin TLS ajusta el puerto 1883 y elimina `setCACert`, pero prioriza seguridad en despliegues reales.
+
+---
+
+## Publicar desde cualquier lugar
+
+- Usa `mosquitto_pub -h broker.tudominio.com -t casa/sala/led -m "ON"`.
+- Implementa dashboards con **Node-RED**, **Home Assistant** o apps móviles como **MQTT Dash**.
+- Para automatización, crea reglas en tu VPS que escuchen webhooks y publiquen en el topic.
+
+---
+
+## Buenas prácticas
+
+1. **Segmenta topics** por ubicación/dispositivo (`casa/sala/led`).
+2. **Habilita TLS y autenticación** para conexiones remotas.
+3. **Implementa Last Will** para detectar desconexiones inesperadas.
+4. **Monitorea** con `mosquitto_sub` o servicios como Grafana + Telegraf.
+
+Con este flujo podrás encender y apagar un LED desde cualquier lugar del mundo usando MQTT y tu ESP32.

--- a/content/posts/electronica/cambiador-rango-opamp/index.md
+++ b/content/posts/electronica/cambiador-rango-opamp/index.md
@@ -1,0 +1,85 @@
+---
+title: "Cambiadores de rango con op-amps"
+date: 2024-03-16T16:30:00+02:00
+description: "Diseño de escaladores y cambiadores de rango utilizando amplificadores operacionales para acondicionamiento de señales."
+menu:
+  sidebar:
+    name: Cambiadores de rango con op-amps
+    identifier: cambiador-rango-opamp
+    parent: electronica
+    weight: 11
+hero: images/cambiador-rango-opamp-cover.jpg
+tags:
+- Amplificadores operacionales
+- Acondicionamiento de señal
+- Instrumentación
+- Diseño analógico
+categories:
+- Electrónica
+- Analógico
+math: true
+---
+
+Cuando un sensor entrega una señal fuera del rango de tu ADC o instrumento, necesitas un **cambiador de rango**. Con amplificadores operacionales puedes desplazar y escalar niveles para aprovechar mejor la resolución disponible.
+
+---
+
+## Objetivo de diseño
+
+Queremos transformar una señal \(V_{in}\) en \(V_{out}\) según:
+
+\[
+V_{out} = a V_{in} + b
+\]
+
+donde \(a\) es la ganancia y \(b\) el offset. Un circuito sumador/restador con op-amp no inversor logra este comportamiento.
+
+---
+
+## Configuración típica
+
+1. **Ganancia ajustable:** usa un amplificador no inversor con resistencias \(R_1\) y \(R_2\), ganancia \(1 + R_2/R_1\).
+2. **Offset programable:** suma una referencia \(V_{ref}\) a través de un divisor y op-amp sumador.
+3. **Fuente de referencia precisa:** TL431, DAC o referencia interna del microcontrolador filtrada.
+4. **Rail-to-rail:** selecciona op-amps que operen dentro del rango de tu suministro y salida.
+
+---
+
+## Ejemplo práctico
+
+Transformar 0–20 mA (convertido a 0–2,5 V sobre resistor de 125 Ω) a 0–5 V para un ADC.
+
+1. Convierte corriente en voltaje: \(V_{sense} = 0\)–2,5 V.
+2. Configura ganancia \(a = 2\) con \(R_2 = R_1\).
+3. Offset \(b = 0\) (no requerido). Resultado: 0–5 V.
+
+Para señales bipolares (por ejemplo -5 a +5 V a 0–3,3 V):
+
+- Ganancia \(a = 0,33\).
+- Offset \(b = 1,65\) usando referencia a mitad de 3,3 V.
+
+---
+
+## Consideraciones de precisión
+
+- **Tolerancia de resistencias:** usa 0,1 % o mejor para errores <1 LSB.
+- **Deriva térmica:** elige op-amps con bajo coeficiente y resistencias de película metálica.
+- **Ruido y ancho de banda:** dimensiona filtros RC para limitar ruido antes del ADC.
+
+---
+
+## Protección
+
+- Añade diodos de **clamp** y resistencias serie para proteger contra sobrevoltajes.
+- Implementa **limitadores** (amplificadores con saturación) para mantener la señal dentro del rango esperado.
+
+---
+
+## Checklist
+
+- [ ] ¿La referencia de offset es estable y filtrada?
+- [ ] ¿El op-amp soporta el rango de entrada/salida?
+- [ ] ¿La ganancia resultante cumple con los límites de tu ADC?
+- [ ] ¿Añadiste filtrado anti-aliasing si el ADC es SAR?
+
+Con estos lineamientos podrás diseñar cambiadores de rango fiables usando amplificadores operacionales.

--- a/content/posts/electronica/capacitancia-parasitaria/index.md
+++ b/content/posts/electronica/capacitancia-parasitaria/index.md
@@ -1,0 +1,77 @@
+---
+title: "Capacitancia parasitaria en PCBs"
+date: 2024-03-16T17:30:00+02:00
+description: "Qué es la capacitancia parasitaria, cómo afecta señales rápidas y estrategias para minimizarla en PCBs."
+menu:
+  sidebar:
+    name: Capacitancia parasitaria en PCBs
+    identifier: capacitancia-parasitaria
+    parent: electronica
+    weight: 13
+hero: images/capacitancia-parasitaria-cover.jpg
+tags:
+- PCB
+- Señales rápidas
+- Integridad de señal
+- Diseño electrónico
+categories:
+- Electrónica
+- Alta velocidad
+math: true
+---
+
+La **capacitancia parasitaria** aparece de forma no intencional entre pistas, planos y componentes. En circuitos de alta velocidad puede degradar bordes, generar diafonía y alterar la respuesta en frecuencia.
+
+---
+
+## De dónde proviene
+
+- **Pistas paralelas:** forman capacitores distribuidos cuando corren cercanas durante largos trayectos.
+- **Pads y planos de referencia:** cada pad hacia un plano crea capacitancia que modifica la impedancia.
+- **Componentes discretos:** encapsulados, cables y conectores poseen capacitancias internas.
+
+Se aproxima con:
+
+\[
+C = \varepsilon \frac{A}{d}
+\]
+
+donde \(A\) es el área de superposición, \(d\) la distancia y \(\varepsilon\) la permitividad.
+
+---
+
+## Efectos en circuitos
+
+- **Aumento del tiempo de subida** en señales digitales: \(t_r \approx 2,2 RC\).
+- **Resonancias** junto con inductancias parásitas formando tanques LC.
+- **Diafonía (crosstalk)** entre trazas paralelas.
+- **Alteración de filtros** analógicos o osciladores LC.
+
+---
+
+## Cómo mitigarlo
+
+1. **Controla la geometría:** mantén separación suficiente entre pistas de alta velocidad.
+2. **Usa planos de referencia sólidos** para definir impedancia y reducir diafonía.
+3. **Reduce áreas expuestas** en pads grandes mediante ventanas en solder mask.
+4. **Acorta leads y cables** en prototipos para disminuir capacitancia añadida.
+5. **Aplica terminaciones adecuadas** (series o en paralelo) para amortiguar efectos.
+
+---
+
+## Herramientas de análisis
+
+- Simuladores de integridad de señal (HyperLynx, SiSoft, Keysight ADS).
+- Calculadoras de impedancia y capacitancia en línea.
+- Medición con **VNA** o **TDR** para validar prototipos.
+
+---
+
+## Checklist de diseño
+
+- [ ] ¿Las pistas críticas siguen reglas de separación e impedancia?
+- [ ] ¿Los planos de retorno están continuos y sin slots?
+- [ ] ¿Se minimizaron stubs en vías y pads?
+- [ ] ¿Se verificó la respuesta mediante simulación o medición?
+
+Controlar la capacitancia parasitaria te permitirá mantener señales limpias y reproducibles en tus PCBs de alta velocidad.

--- a/content/posts/electronica/escoger-baterias/index.md
+++ b/content/posts/electronica/escoger-baterias/index.md
@@ -1,0 +1,75 @@
+---
+title: "Cómo escoger baterías"
+date: 2024-03-16T10:00:00+02:00
+description: "Comparativa entre LiPo, LiFePO4, plomo-ácido y otras químicas para alimentar proyectos electrónicos."
+menu:
+  sidebar:
+    name: Cómo escoger baterías
+    identifier: escoger-baterias
+    parent: electronica
+    weight: 10
+hero: images/escoger-baterias-cover.jpg
+tags:
+- Baterías
+- Alimentación
+- Energía portátil
+- Power design
+categories:
+- Electrónica
+- Energía
+---
+
+Elegir la batería correcta evita apagones, sobrecalentamientos y ciclos de vida cortos. Esta guía resume las químicas más comunes, sus parámetros clave y criterios para combinarlas con tu electrónica.
+
+---
+
+## Parámetros críticos
+
+1. **Voltaje nominal y rango operativo.** Asegúrate de que la tensión se mantenga dentro del margen de tu electrónica y reguladores.
+2. **Capacidad (mAh o Wh).** Calcula el consumo promedio y el pico. Multiplica por el tiempo deseado y agrega un 20–30 % de margen.
+3. **Capacidad de descarga (C-rate).** Determina la corriente máxima continua y en ráfagas.
+4. **Ciclo de vida.** Considera cuántos ciclos completos soporta antes de caer al 80 %.
+5. **Temperatura y seguridad.** Verifica límites de operación y si necesitas circuitos de protección.
+
+---
+
+## Tabla comparativa
+
+| Química | Voltaje por celda | Densidad energética | C-rate típica | Puntos fuertes | Precauciones |
+| --- | --- | --- | --- | --- | --- |
+| LiPo (Li-ion polímero) | 3,7 V (2,7–4,2 V) | Muy alta | 1C–35C | Ligera, entrega altas corrientes. | Necesita balanceo y protección contra sobrecarga/descarga. |
+| LiFePO₄ | 3,2 V (2,5–3,6 V) | Media | 1C–5C | Segura, >2000 ciclos, estable térmicamente. | Voltaje por celda menor, requiere más celdas en serie. |
+| Plomo-ácido (SLA, AGM) | 2,0 V (1,8–2,4 V) | Baja | 0,2C–1C | Económica, disponible en altos Ah. | Pesada, no tolera descargas profundas continuas. |
+| NiMH | 1,2 V (1,0–1,4 V) | Media | 0,5C–5C | Robusta, fácil de cargar. | Autodescarga alta, requiere cargador inteligente. |
+| 18650 Li-ion | 3,6 V (2,5–4,2 V) | Muy alta | 1C–10C | Modular, buena densidad. | Igual que LiPo: protección obligatoria. |
+
+---
+
+## Seleccionar el formato
+
+- **Drones y robótica móvil:** LiPo por su alta potencia instantánea. Incluye monitorización individual de celdas y bolsas ignífugas.
+- **IoT estacionario o respaldo:** LiFePO₄ por seguridad y longevidad. Combina con BMS y cargador CC/CV dedicado.
+- **Prototipos económicos:** Pack de NiMH AA recargables o SLA pequeño. Aceptan maltrato y son fáciles de encontrar.
+- **Aplicaciones industriales 24/7:** LiFePO₄ o Li-ion con celdas 18650 de calidad, gestionadas con BMS redundante y telemetría.
+
+---
+
+## Gestión y protección
+
+1. **Incluye un BMS adecuado.** Asegura balanceo, corte por sobrecorriente y protección térmica.
+2. **Dimensiona el cargador.** La corriente recomendada suele ser 0,5C para LiPo/Li-ion y 0,3C para LiFePO₄.
+3. **Regulación de voltaje.** Usa convertidores buck/boost para entregar tensiones estables a tu circuito.
+4. **Plan de almacenamiento.** LiPo al 40–60 % y en bolsas ignífugas; plomo-ácido siempre cargadas.
+5. **Monitoreo en campo.** Integra medidores de coulomb, estimación de SoC y alarmas de temperatura.
+
+---
+
+## Checklist rápido
+
+- [ ] ¿La química soporta la corriente pico de tu carga?
+- [ ] ¿Tu BMS controla temperatura, balance y sobrecarga?
+- [ ] ¿El cargador respeta curvas CC/CV o delta-peak según la química?
+- [ ] ¿La caja o chasis incluye ventilación y protección mecánica?
+- [ ] ¿Documentaste procedimiento de transporte y reciclaje?
+
+Con estos pasos podrás seleccionar una batería que equilibre seguridad, autonomía y costo sin sorpresas en el laboratorio ni en campo.

--- a/content/posts/electronica/motor-a-pasos/index.md
+++ b/content/posts/electronica/motor-a-pasos/index.md
@@ -1,0 +1,132 @@
+---
+title: "¿Qué es un motor a pasos y cómo aprovecharlo?"
+date: 2024-03-15T09:00:00+02:00
+description: "Conceptos clave para entender los motores a pasos: tipos, funcionamiento, drivers, aplicaciones y criterios para elegir el modelo correcto."
+menu:
+  sidebar:
+    name: Motores a pasos
+    identifier: motor-a-pasos
+    parent: electronica
+    weight: 8
+hero: images/motor-a-pasos-cover.jpg
+tags:
+- Motores a pasos
+- CNC
+- Impresión 3D
+- Control de motores
+- Electrónica de potencia
+categories:
+- Electrónica
+- Control de movimiento
+- Mecatrónica
+---
+
+Los **motores a pasos** (stepper motors) convierten pulsos eléctricos en **movimientos angulares discretos**. En cada paso el eje gira un ángulo fijo (1,8°, 0,9°, etc.), por lo que podemos posicionar cargas sin retroalimentación mecánica adicional.
+
+---
+
+## ¿Cómo funciona un motor a pasos?
+
+Un motor a pasos típico tiene:
+
+- **Estator** con varias bobinas agrupadas en fases.
+- **Rotor** dentado con imanes permanentes o material ferroso.
+- **Secuencia de excitación**: aplicar corriente a las bobinas en un orden preciso genera un campo magnético rotatorio que “arrastra” al rotor.
+
+Cada vez que cambiamos la fase energizada el rotor avanza un **paso**. Si completamos \(N\) pasos obtenemos una vuelta completa, y podemos calcular los pasos por vuelta como:
+
+\[
+\text{pasos por vuelta} = \frac{360^{\circ}}{\text{ángulo por paso}}
+\]
+
+Por ejemplo, un motor de 1,8° necesita 200 pasos para girar 360°.
+
+---
+
+## Modos de operación
+
+- **Pasos completos**: energiza una fase a la vez. Ofrece el par nominal pero la resolución está limitada al ángulo por paso.
+- **Medios pasos**: alterna entre una fase y dos fases activas. Duplica la resolución (1,8° → 0,9°) con ligero rizado de par.
+- **Microstepping**: el driver modula corrientes senoidales para dividir cada paso en hasta 1/256. Reduce vibraciones y resonancias, ideal para impresoras 3D y CNC pequeños.
+
+---
+
+## Tipos de motores a pasos
+
+| Tipo | Características | Ventajas | Desventajas | Casos típicos |
+| --- | --- | --- | --- | --- |
+| **Reluctancia variable** | Rotor dentado sin imanes. | Construcción económica, respuesta rápida. | Bajo par y fácil pérdida de pasos. | Instrumentación, actuadores ligeros. |
+| **Imán permanente** | Rotor con imanes axiales. | Par moderado con electrónica simple. | Tamaño reducido, limitado en velocidad. | Escáneres, cámaras, actuadores lineales. |
+| **Híbrido (PM + reluctancia)** | Combina imanes y dientes finos (1,8° o 0,9°). | Alto par/volumen, buena precisión. | Precio y necesidad de drivers más finos. | CNC, impresoras 3D, robótica ligera. |
+
+También encontrarás configuraciones **unipolares** (cada fase dividida en dos enrollados con derivación central, fáciles de manejar con transistores o ULN2003) y **bipolares** (una bobina por fase, requieren puentes H pero ofrecen más par por cobre).
+
+---
+
+## ¿Dónde se usan los motores a pasos?
+
+- **Impresoras 3D y CNC de escritorio**: posicionamiento de ejes XYZ y extrusores.
+- **Robótica y automatización ligera**: pórticos pick-and-place, dispensadores de componentes.
+- **Instrumentación y medición**: control de válvulas, galvanómetros digitales, ópticas.
+- **Electrónica de consumo**: unidades de disquete, lentes de cámaras, lectores de tarjetas.
+
+Su mayor fortaleza es el **posicionamiento abierto (open-loop)** con buena repetibilidad sin necesidad de encoders.
+
+---
+
+## Drivers y técnicas de control
+
+Para moverlos correctamente necesitas un **driver** que entregue corriente controlada:
+
+- **ULN2003 / ULN2803**: matrices Darlington para motores unipolares pequeños (28BYJ-48). Control tipo paso a paso desde un microcontrolador.
+- **L298N / L293D**: puentes H clásicos. Funcionan, pero son ineficientes para corrientes altas.
+- **A4988, DRV8825, TMC2208/2209**: drivers de micropasos con regulación de corriente por chopping, ideales para motores bipolares de 1–2 A.
+- **Drivers industriales (Leadshine, Gecko, etc.)**: aceptan señales STEP/DIR o comunicación digital y pueden trabajar a decenas de voltios y amperios.
+
+Buenas prácticas de control:
+
+1. **Regular la corriente**: el par depende de la corriente RMS, no del voltaje. Ajusta los potenciómetros o usa drivers con autoajuste.
+2. **Aumentar el voltaje de alimentación**: dentro del rango del driver, un voltaje más alto vence la inductancia y mantiene el par a alta velocidad.
+3. **Rampas de aceleración/desaceleración**: evita perder pasos al arrancar o detener cargas inerciales.
+4. **Evitar resonancias**: prueba diferentes microsteppings y añade amortiguadores o correas para suavizar vibraciones.
+
+---
+
+## Cómo elegir el motor correcto
+
+1. **Par requerido**
+   - Calcula el par de carga (Nm o kg·cm). Añade un 30–50 % de margen para fricción y aceleración.
+2. **Ángulo por paso / resolución**
+   - ¿Necesitas 200 pasos por vuelta (1,8°) o 400 pasos (0,9°)? Considera el microstepping disponible.
+3. **Tamaño y estándar NEMA**
+   - NEMA 17, 23, 34… indica el tamaño de la brida en pulgadas ×10. A mayor tamaño, más par.
+4. **Corriente nominal y resistencia de bobina**
+   - Define el driver y la fuente. Motores de baja resistencia funcionan mejor con drivers de corriente constante.
+5. **Velocidad máxima**
+   - Revisa curvas par–velocidad. El par cae a medida que aumenta la velocidad, especialmente en motores grandes con inductancia alta.
+6. **Tipo de eje y acople**
+   - Ejes lisos, estriados, con doble salida. Facilita el montaje en poleas, acoples flexibles o husillos.
+7. **Ambiente y ciclo de trabajo**
+   - Temperaturas elevadas o operación 24/7 requieren revisar aislamiento, ventilación y límites térmicos.
+
+---
+
+## Checklist rápido antes de comprar
+
+- [ ] ¿El driver soporta la corriente RMS del motor?
+- [ ] ¿La fuente de alimentación entrega el voltaje y corriente suficientes?
+- [ ] ¿Incluiste rampas de aceleración en el firmware?
+- [ ] ¿El montaje mecánico evita cargas laterales en el eje?
+- [ ] ¿Necesitas un encoder o final de carrera como respaldo?
+
+---
+
+## Consejos finales
+
+- **Protege tus bobinas**: usa diodos flyback o drivers con protección integrada.
+- **Mide la temperatura** durante las pruebas. Un motor a pasos puede operar caliente (70–80 °C superficial), pero si no puedes tocarlo más de 2 segundos, revisa la corriente.
+- **Cuida el cableado**: pares trenzados y blindaje reducen interferencias cuando el cable es largo.
+- **Documenta la secuencia de cables**: usa etiquetas o conectores para evitar errores de conexión.
+
+Con una selección adecuada y un driver bien configurado, los motores a pasos ofrecen **precisión repetible, costos razonables** y un ecosistema maduro para proyectos de automatización, robótica y fabricación digital.
+

--- a/content/posts/electronica/proteccion-inversion/index.md
+++ b/content/posts/electronica/proteccion-inversion/index.md
@@ -1,0 +1,71 @@
+---
+title: "Protección contra inversión de polaridad"
+date: 2024-03-16T17:00:00+02:00
+description: "Estrategias para proteger PCBs ante inversión de polaridad usando diodos, MOSFET y controladores dedicados."
+menu:
+  sidebar:
+    name: Protección contra inversión de polaridad
+    identifier: proteccion-inversion
+    parent: electronica
+    weight: 12
+hero: images/proteccion-inversion-cover.jpg
+tags:
+- Protección eléctrica
+- MOSFET
+- PCB design
+- Fuentes de alimentación
+categories:
+- Electrónica
+- Energía
+---
+
+Conectar una fuente al revés puede destruir componentes y pistas. Implementar **protección contra inversión de polaridad** es obligatorio en PCBs expuestas a usuarios finales o mantenimiento en campo.
+
+---
+
+## Métodos comunes
+
+### Diodo en serie
+
+- Coloca un diodo Schottky en serie con la entrada.
+- Ventaja: simplicidad extrema.
+- Desventaja: caída de tensión (~0,3–0,5 V) y pérdida de potencia.
+
+### Diodo en paralelo + fusible
+
+- Diodo TVS o rectificador en antiparalelo, fusible o PTC en serie.
+- Si se invierte la polaridad, el diodo conduce y el fusible abre.
+- Adecuado para fuentes de alto voltaje con usuarios experimentados.
+
+### MOSFET de canal P
+
+- Configura un MOSFET P-channel con el cuerpo diode apuntando hacia la carga.
+- Ofrece baja caída de tensión (mΩ) y protección bidireccional limitada.
+- Cuidado con el **V_GS max** al usar fuentes por encima de 20 V.
+
+### MOSFET de canal N ideal
+
+- Usa un MOSFET N con controlador de puerta ideal (por ejemplo, **LTC4365**, **LM5060**).
+- Proporciona protección bidireccional, limitación de corriente y detección de sobrevoltaje.
+- Recomendado en fuentes industriales y baterías Li-ion de alto corriente.
+
+---
+
+## Consideraciones de diseño
+
+1. **Rango de voltaje:** dimensiona componentes para el máximo esperado más margen.
+2. **Corriente nominal:** MOSFET con \(R_{DS(on)}\) bajo y disipación calculada.
+3. **Respuesta térmica:** añade planos de cobre y vias para disipar calor.
+4. **Diagnóstico:** LEDs o indicadores que alerten de polaridad invertida.
+5. **Pruebas:** aplica inversión con fuentes limitadas en corriente para validar que no se dañe la placa.
+
+---
+
+## Layout PCB
+
+- Coloca la protección cerca del conector de entrada.
+- Usa pistas cortas y anchas para reducir inductancia.
+- Añade TVS adicionales para transientes rápidos.
+- Documenta claramente la polaridad en serigrafía y manuales.
+
+Con estas estrategias podrás diseñar PCBs robustas que soporten errores de conexión sin comprometer el rendimiento.

--- a/content/posts/electronica/pull-up-pull-down/index.md
+++ b/content/posts/electronica/pull-up-pull-down/index.md
@@ -1,0 +1,90 @@
+---
+title: "Pull-up vs pull-down"
+date: 2024-03-16T09:00:00+02:00
+description: "Cómo elegir y dimensionar resistencias pull-up y pull-down para entradas digitales confiables."
+menu:
+  sidebar:
+    name: Pull-up vs pull-down
+    identifier: pull-up-pull-down
+    parent: electronica
+    weight: 9
+hero: images/pull-up-pull-down-cover.jpg
+tags:
+- Resistencias
+- Entradas digitales
+- Microcontroladores
+- Diseño electrónico
+categories:
+- Electrónica
+- Básico
+math: true
+---
+
+Las entradas digitales en microcontroladores, FPGAs o sensores necesitan una referencia estable de nivel lógico cuando el pulsador o dispositivo externo está abierto. Para lograrlo usamos **resistencias pull-up y pull-down**. Saber cuándo elegir cada una evita lecturas erráticas y consumo innecesario.
+
+---
+
+## Qué hace una resistencia pull-up
+
+Una **pull-up** conecta la entrada a \(V_{CC}\) mediante una resistencia. Cuando el botón está abierto la entrada lee un "1" lógico; al cerrar el contacto hacia tierra, la corriente fluye a través de la resistencia y el nodo cae a "0".
+
+Ventajas principales:
+
+- Permite usar interruptores a GND, que suelen tener menos ruido.
+- Compatible con buses open-drain/open-collector (I²C, 1-Wire).
+- Protege el pin ante cortos accidentales a tierra limitando la corriente a \(I = \frac{V_{CC}}{R}\).
+
+Cuida que el nivel alto cumpla la ecuación:
+
+\[
+V_{INH} = V_{CC} - I_{leak} \cdot R_{PU}
+\]
+
+donde \(I_{leak}\) es la corriente de fuga del pin. Si el resultado baja del umbral lógico alto, reduce el valor de la resistencia.
+
+---
+
+## Qué hace una resistencia pull-down
+
+Una **pull-down** amarra la entrada a tierra. El pin lee "0" en reposo y sube a "1" cuando se conecta a \(V_{CC}\).
+
+Se usa cuando:
+
+- El dispositivo externo entrega un nivel alto activo (sensores NPN open-collector, PLCs de 24 V con optoacopladores).
+- Se requieren interruptores a \(V_{CC}\) por motivos de seguridad (por ejemplo, detectar cable cortado).
+- El pin interno solo ofrece pull-up configurable y necesitas el estado contrario.
+
+---
+
+## Cómo dimensionar el valor
+
+La resistencia debe ser lo suficientemente baja para vencer corrientes de fuga y EMI, pero alta para limitar consumo.
+
+| Contexto | Rango típico |
+| --- | --- |
+| Buses I²C 3,3 V (100 kHz) | 2,2 kΩ – 4,7 kΩ |
+| Entradas GPIO generales | 4,7 kΩ – 47 kΩ |
+| Entradas de alta impedancia (comparadores) | 100 kΩ – 1 MΩ |
+
+Si hay **capacitancia parásita** en el nodo, el tiempo de subida \(t_r = 2,2 R C\). A mayor R o C, más lento el flanco: considera reducir el valor o colocar un buffer Schmitt trigger.
+
+---
+
+## Pull-ups internas vs externas
+
+La mayoría de microcontroladores incluyen pull-ups/pull-downs configurables (10 kΩ – 50 kΩ). Úsalas para prototipos, pero añade componentes externos cuando:
+
+- Necesitas valores más precisos o fuertes (1 kΩ) para buses rápidos.
+- El pin debe soportar más de \(V_{CC}\) (por ejemplo, 12 V con optoacopladores).
+- Requieres tolerancia térmica y confiabilidad a largo plazo.
+
+---
+
+## Buenas prácticas
+
+1. **Documenta la lógica activa** en esquemáticos y firmware. Evita invertir señales por error.
+2. **Añade filtrado RC** en líneas expuestas a cables largos.
+3. **Combina con protección ESD** mediante diodos TVS si el pin sale al exterior.
+4. **Verifica el consumo en reposo**: con 3,3 V y una pull-down de 4,7 kΩ, el botón presionado consume ~0,7 mA.
+
+Con estos criterios podrás definir rápidamente qué estrategia usar y garantizar que tus entradas digitales sean estables en cualquier entorno.

--- a/content/posts/hardware-digital/_index.en.md
+++ b/content/posts/hardware-digital/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: Digital hardware
+menu:
+  sidebar:
+    name: Digital hardware
+    identifier: digital-hardware
+    weight: 7
+---

--- a/content/posts/hardware-digital/_index.md
+++ b/content/posts/hardware-digital/_index.md
@@ -1,0 +1,8 @@
+---
+title: Hardware digital
+menu:
+  sidebar:
+    name: Hardware digital
+    identifier: hardware-digital
+    weight: 7
+---

--- a/content/posts/hardware-digital/fpga-introduccion/index.md
+++ b/content/posts/hardware-digital/fpga-introduccion/index.md
@@ -1,0 +1,82 @@
+---
+title: "FPGAs"
+date: 2024-03-16T19:00:00+02:00
+description: "Introducción a las FPGAs, arquitectura interna, flujo de diseño y aplicaciones típicas."
+menu:
+  sidebar:
+    name: FPGAs
+    identifier: fpga-introduccion
+    parent: hardware-digital
+    weight: 1
+hero: images/fpga-introduccion-cover.jpg
+tags:
+- FPGA
+- Diseño digital
+- HDL
+- Electrónica
+categories:
+- Hardware digital
+- Diseño digital
+---
+
+Las **FPGAs (Field Programmable Gate Arrays)** son dispositivos lógicos reconfigurables que permiten implementar hardware personalizado mediante lenguajes HDL. Ofrecen paralelismo masivo y tiempos deterministas que superan a los microcontroladores convencionales en tareas específicas.
+
+---
+
+## Arquitectura básica
+
+- **Bloques lógicos configurables (CLB):** contienen LUTs, flip-flops y multiplexores.
+- **Red de interconexión programable:** conecta LUTs y bloques especializados.
+- **Bloques de memoria (BRAM) y UltraRAM:** almacenamiento de baja latencia.
+- **DSP slices:** multiplicadores y acumuladores optimizados.
+- **I/O programables:** soportan estándares LVDS, LVCMOS, SerDes, etc.
+
+---
+
+## Flujo de diseño
+
+1. **Descripción HDL** (VHDL, Verilog, SystemVerilog) o herramientas de alto nivel (HLS, OpenCL).
+2. **Sintetizado**: convierte el HDL en una red lógica.
+3. **Implementación (place & route):** asigna recursos físicos y rutas de interconexión.
+4. **Generación de bitstream**: archivo que configura la FPGA.
+5. **Programación** mediante JTAG, SPI flash o procesadores integrados.
+
+---
+
+## Familias populares
+
+| Fabricante | Serie | Rasgos |
+| --- | --- | --- |
+| Xilinx/AMD | Artix-7, Kintex-7, Zynq | Buena relación costo/rendimiento, SoC con ARM Cortex-A9. |
+| Intel/Altera | Cyclone V, MAX 10, Arria | Opciones desde bajo costo hasta alto desempeño. |
+| Lattice | iCE40, ECP5, Nexus | Bajo consumo, ideales para IoT y dispositivos portátiles. |
+| Gowin | LittleBee, Arora | Alternativa económica con herramientas accesibles. |
+
+---
+
+## Aplicaciones
+
+- **Procesamiento de señales** (radar, SDR, visión por computadora).
+- **Puentes de comunicación** (PCIe, Ethernet, protocolos personalizados).
+- **Control industrial** con tiempos deterministas.
+- **Prototipado de ASIC** y emulación de hardware.
+
+---
+
+## Ecosistema de herramientas
+
+- **Vivado / Vitis** (Xilinx), **Quartus Prime** (Intel), **Radiant / Diamond** (Lattice).
+- Flujos open source: **Yosys + nextpnr**, **SymbiFlow**, **OpenFPGA**.
+- Lenguajes de alto nivel: **Migen**, **nMigen**, **Chisel**, **SpinalHDL**.
+
+---
+
+## Consejos para principiantes
+
+1. Empieza con placas accesibles (iCEstick, DE0-Nano, Arty A7).
+2. Practica con diseños simples: contadores, PWM, UART.
+3. Usa **simulación** (GHDL, ModelSim) antes de sintetizar para atrapar bugs.
+4. Gestiona los **constraints** de tiempo y pines en archivos `.xdc` o `.sdc`.
+5. Documenta versiones de herramientas; pequeñas diferencias pueden cambiar resultados.
+
+Con esta base podrás adentrarte en el mundo de las FPGAs y escoger la plataforma adecuada para tus proyectos de diseño digital.

--- a/content/posts/microcontroladores/_index.en.md
+++ b/content/posts/microcontroladores/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: Microcontrollers
+menu:
+  sidebar:
+    name: Microcontrollers
+    identifier: microcontrollers
+    weight: 2
+---

--- a/content/posts/microcontroladores/_index.md
+++ b/content/posts/microcontroladores/_index.md
@@ -1,0 +1,8 @@
+---
+title: Microcontroladores
+menu:
+  sidebar:
+    name: Microcontroladores
+    identifier: microcontroladores
+    weight: 2
+---

--- a/content/posts/microcontroladores/elegir-esp32/index.md
+++ b/content/posts/microcontroladores/elegir-esp32/index.md
@@ -1,0 +1,65 @@
+---
+title: "Elegir la ESP32 adecuada"
+date: 2024-03-16T11:30:00+02:00
+description: "Comparación entre los módulos y devkits ESP32 más comunes para seleccionar el ideal según conectividad y recursos."
+menu:
+  sidebar:
+    name: Elegir la ESP32 adecuada
+    identifier: elegir-esp32
+    parent: microcontroladores
+    weight: 2
+hero: images/elegir-esp32-cover.jpg
+tags:
+- ESP32
+- IoT
+- Wi-Fi
+- Bluetooth
+categories:
+- Microcontroladores
+- IoT
+---
+
+La familia **ESP32** de Espressif incluye docenas de variantes con diferentes radios, memoria y encapsulados. Escoger el módulo correcto evita limitaciones de memoria, consumo excesivo o falta de certificaciones inalámbricas.
+
+---
+
+## Criterios de selección
+
+1. **Conectividad inalámbrica.** ¿Necesitas Wi-Fi 2,4 GHz, Bluetooth LE, Classic o incluso 802.15.4?
+2. **Memoria y almacenamiento.** Flash integrada (4–16 MB), PSRAM opcional para buffers gráficos o voz.
+3. **GPIO disponibles.** Algunos módulos comparten pines con la antena o el cristal, reduciendo los I/O libres.
+4. **Certificaciones.** Para productos finales busca módulos con FCC/CE y antena integrada.
+5. **Consumo energético.** Evalúa modos de suspensión, corriente en deep sleep y voltaje operativo.
+
+---
+
+## Variantes populares
+
+| Módulo | CPU | RAM/Flash | Radios | Características clave |
+| --- | --- | --- | --- | --- |
+| ESP32-WROOM-32 | Xtensa LX6 dual a 240 MHz | 520 KB + 4 MB flash | Wi-Fi + BT Classic/LE | DevkitC, amplio soporte, antena PCB. |
+| ESP32-WROVER | Xtensa LX6 dual | 520 KB + 4 MB flash + 8 MB PSRAM | Wi-Fi + BT | Ideal para gráficos, cámaras o SSL pesado. |
+| ESP32-C3 | RISC-V single 160 MHz | 400 KB + 4 MB flash | Wi-Fi + BT LE 5 | Bajo consumo, pin-to-pin con ESP8266. |
+| ESP32-S3 | Xtensa LX7 dual 240 MHz | 512 KB + 8 MB flash/PSRAM | Wi-Fi + BT LE 5 | Vector instructions para IA, USB OTG. |
+| ESP32-C6 | RISC-V single 160 MHz | 512 KB + 4 MB flash | Wi-Fi 6 + BT LE 5 + 802.15.4 | Thread/Matter listo, eficiente. |
+
+---
+
+## Devkits recomendados
+
+- **ESP32-DevKitC:** Referencia básica para WROOM. Incluye convertidor USB-UART y fácil acceso a pines.
+- **ESP32-S3-DevKitC-1:** Para proyectos de visión gracias a USB nativo y soporte para cámaras.
+- **ESP32-C3-DevKitM-1:** Ideal para wearables y sensores de baja potencia.
+- **LilyGO T-Display / T-Embed:** Añaden pantalla IPS, ranura microSD y batería LiPo integrada.
+
+---
+
+## Consejos prácticos
+
+1. **Define primero la pila de software.** ESP-IDF, Arduino Core, MicroPython o circuitos con Matter pueden requerir memoria adicional.
+2. **Revisa el pinout oficial.** Algunos GPIO no toleran 5 V o están reservados para arranque (GPIO0, GPIO2, GPIO15).
+3. **Planea la antena.** Respeta el keep-out de la PCB o el conector U.FL para no degradar la potencia.
+4. **Aprovecha los modos de bajo consumo.** Configura RTC, ULP y wake-up por GPIO o temporizador para aplicaciones alimentadas por batería.
+5. **Certifica tu producto.** Usa módulos pre-certificados y documenta las pruebas de radiofrecuencia.
+
+Con esta matriz podrás elegir el módulo ESP32 que mejor se ajuste a tu presupuesto, consumo y requisitos de conectividad.

--- a/content/posts/microcontroladores/extender-entradas-i2c/index.md
+++ b/content/posts/microcontroladores/extender-entradas-i2c/index.md
@@ -1,0 +1,75 @@
+---
+title: "Ampliar entradas digitales con I2C"
+date: 2024-03-16T18:00:00+02:00
+description: "Cómo extender las entradas digitales de la Raspberry Pi Pico usando expansores GPIO I2C como el MCP23017 o el PCF8575."
+menu:
+  sidebar:
+    name: Ampliar entradas digitales con I2C
+    identifier: extender-entradas-i2c
+    parent: microcontroladores
+    weight: 5
+hero: images/extender-entradas-i2c-cover.jpg
+tags:
+- Raspberry Pi Pico
+- I2C
+- Expansores GPIO
+- Hardware modular
+categories:
+- Microcontroladores
+- IoT
+---
+
+Cuando el número de GPIO de la Raspberry Pi Pico no basta, puedes **ampliar entradas digitales** con expansores I2C. Estos integrados entregan 8, 16 o más pines configurables sin sacrificar recursos del microcontrolador.
+
+---
+
+## Expansores populares
+
+| Chip | Bits | Voltaje | Características |
+| --- | --- | --- | --- |
+| MCP23017 | 16 | 1,8–5,5 V | Dos bancos de 8 bits, interrupciones configurables, pull-ups internos. |
+| PCF8575 | 16 | 2,5–5,5 V | Entradas/salidas quasi-bidireccionales, ideal para lectura de botones. |
+| TCA9555 | 16 | 2,3–5,5 V | Interrupciones separadas, compatible con 400 kHz. |
+| SX1509 | 16 | 2,5–3,6 V | PWM por pin, debounce interno y lógica de interrupciones avanzada. |
+
+---
+
+## Conexión básica
+
+1. Conecta SDA y SCL al bus I2C de la Pico (GPIO 4 y 5 por defecto) con **pull-ups de 4,7 kΩ**.
+2. Alimenta el expansor con 3,3 V o el voltaje requerido.
+3. Configura las direcciones mediante pines A0-A2.
+4. Conecta pines de interrupción (INTA/INTB) a GPIO disponibles para detectar cambios sin sondeo constante.
+
+---
+
+## Ejemplo con MCP23017 en MicroPython
+
+```python
+from machine import I2C, Pin
+from mcp23017 import MCP23017
+
+i2c = I2C(0, scl=Pin(5), sda=Pin(4), freq=400000)
+exp = MCP23017(i2c, address=0x20)
+exp.setup(0, MCP23017.IN, pullup=True)
+exp.setup(1, MCP23017.IN, pullup=True)
+
+while True:
+    estado0 = exp.input(0)
+    estado1 = exp.input(1)
+    # Procesa botones
+```
+
+En C/C++ utiliza la librería `hardware/i2c.h` y escribe a los registros `IODIRA`, `GPPUA` y `GPIOA`.
+
+---
+
+## Buenas prácticas
+
+1. **Aísla dominios de voltaje** si conectas señales de 5 V; algunos expansores toleran 5 V sólo en entradas.
+2. **Debounce por hardware o firmware** para evitar falsos positivos en botones.
+3. **Gestiona interrupciones** leyendo ambos puertos para limpiar flags.
+4. **Escala el bus**: I2C soporta hasta 8 dispositivos por dirección si usas diferentes direcciones.
+5. **Considera SPI** si necesitas velocidades mayores; chips como MCP23S17 ofrecen interfaz alternativa.
+
+Con expansores I2C podrás incrementar las entradas digitales de tu Pico sin rediseñar la placa principal.

--- a/content/posts/microcontroladores/instalar-micro-ros-pico/index.md
+++ b/content/posts/microcontroladores/instalar-micro-ros-pico/index.md
@@ -1,0 +1,106 @@
+---
+title: "Instalar micro-ROS en la Pico"
+date: 2024-03-16T18:30:00+02:00
+description: "Procedimiento para integrar micro-ROS en la Raspberry Pi Pico usando el Pico SDK y colcon."
+menu:
+  sidebar:
+    name: Instalar micro-ROS en la Pico
+    identifier: instalar-micro-ros-pico
+    parent: microcontroladores
+    weight: 6
+hero: images/instalar-micro-ros-pico-cover.jpg
+tags:
+- micro-ROS
+- Raspberry Pi Pico
+- ROS 2
+- Embedded
+categories:
+- Microcontroladores
+- Robótica
+---
+
+**micro-ROS** lleva ROS 2 a microcontroladores con recursos limitados. A continuación se describe cómo configurar el build system para la Raspberry Pi Pico utilizando el Pico SDK oficial.
+
+---
+
+## Prerrequisitos
+
+- Toolchain Arm (`arm-none-eabi-gcc`), CMake y Ninja.
+- ROS 2 Humble (o posterior) instalado en tu sistema.
+- Repositorio `micro_ros_setup` clonado en el workspace de ROS 2.
+- Pico SDK inicializado (`PICO_SDK_PATH`).
+
+---
+
+## Configurar el workspace
+
+```bash
+source /opt/ros/humble/setup.bash
+mkdir -p ~/micro_ros_ws/src
+cd ~/micro_ros_ws/src
+git clone https://github.com/micro-ROS/micro_ros_setup.git
+cd ..
+colcon build
+source install/local_setup.bash
+```
+
+---
+
+## Crear firmware para la Pico
+
+1. **Importa los repositorios necesarios**:
+
+```bash
+ros2 run micro_ros_setup create_firmware_ws.sh freertos raspberripi_pico
+```
+
+2. **Descarga dependencias**:
+
+```bash
+ros2 run micro_ros_setup configure_firmware.sh freertos raspberripi_pico
+```
+
+3. **Compila** con opciones personalizadas (Wi-Fi deshabilitada por defecto):
+
+```bash
+ros2 run micro_ros_setup build_firmware.sh
+```
+
+4. El resultado (`firmware.uf2`) se genera en `firmware/build`. Cópialo a la Pico en modo BOOTSEL.
+
+---
+
+## Ejemplo: nodo ping
+
+Tras flashear, conecta la Pico por USB y ejecuta en el host:
+
+```bash
+ros2 run micro_ros_agent micro_ros_agent serial --dev /dev/ttyACM0 -b 115200
+```
+
+En otra terminal:
+
+```bash
+ros2 topic echo /micro_ros/ping
+```
+
+Deberías ver paquetes periódicos generados por el firmware de ejemplo.
+
+---
+
+## Personalizar el proyecto
+
+- Edita `firmware/freertos_apps/apps/ping_pong/main.c` para crear tus propios nodos.
+- Ajusta memoria en `pico_hw_description.cmake` según tus necesidades de pila y heap.
+- Integra sensores usando `rclc` y colas de mensajes confiables (`rmw_microxrcedds`).
+
+---
+
+## Buenas prácticas
+
+1. Actualiza periódicamente `micro_ros_setup` para obtener parches de compatibilidad.
+2. Usa **colcon profiles** para separar builds de depuración y liberación.
+3. Registra el hash del commit del Pico SDK y micro-ROS en tu documentación.
+4. Automatiza generación de `.uf2` en CI para mantener firmware consistente.
+
+Siguiendo estos pasos ejecutarás micro-ROS en la Raspberry Pi Pico con el SDK oficial listo para integrarse en sistemas ROS 2.

--- a/content/posts/microcontroladores/modulos-pio/index.md
+++ b/content/posts/microcontroladores/modulos-pio/index.md
@@ -1,0 +1,79 @@
+---
+title: "Módulos PIO en la Pico"
+date: 2024-03-16T13:00:00+02:00
+description: "Cómo funcionan los módulos PIO de la Raspberry Pi Pico y ejemplos prácticos para crear periféricos personalizados."
+menu:
+  sidebar:
+    name: Módulos PIO en la Pico
+    identifier: modulos-pio
+    parent: microcontroladores
+    weight: 3
+hero: images/modulos-pio-cover.jpg
+tags:
+- PIO
+- Raspberry Pi Pico
+- RP2040
+- Protocolos personalizados
+categories:
+- Microcontroladores
+- Hardware
+---
+
+Los **módulos PIO (Programmable I/O)** del RP2040 permiten implementar periféricos programables sin cargar la CPU. Con dos bloques PIO y cuatro máquinas de estado cada uno, puedes crear controladores para protocolos no soportados de forma nativa.
+
+---
+
+## Arquitectura PIO
+
+- **Máquinas de estado:** hasta 4 por bloque, cada una con 32 instrucciones de 16 bits.
+- **FIFO TX/RX:** buffers de 4 palabras para intercambio con la CPU o DMA.
+- **Pins flexibles:** mapeo independiente para entrada, salida y side-set.
+- **Clock divider:** ajusta la frecuencia de ejecución con resolución fraccional.
+
+---
+
+## Flujo de trabajo
+
+1. Escribe el programa PIO en ensamblador específico (`.program`).
+2. Carga el código en la instrucción memory del bloque PIO.
+3. Configura los registros de control (SM, clocks, pins).
+4. Usa la API del SDK o MicroPython para enviar/recibir datos.
+
+---
+
+## Ejemplos prácticos
+
+### WS2812 (NeoPixel)
+
+- Genera los pulsos de 800 kHz con side-set para controlar tiras RGB.
+- Libera a la CPU para calcular animaciones mientras PIO gestiona la temporización.
+
+### Interfaces VGA/DVI
+
+- Emite señales de sincronía y datos de vídeo usando múltiples máquinas coordinadas.
+- Requiere DMA para alimentar los buffers a alta velocidad.
+
+### Captura de señales
+
+- Configura una máquina PIO en modo `IN` para muestrear pines a alta frecuencia.
+- Vuelca los datos a memoria mediante DMA para análisis posterior.
+
+---
+
+## Consejos de implementación
+
+1. **Planifica el ancho de palabra.** Ajusta `push`/`pull` y shift registers para empaquetar datos eficientemente.
+2. **Utiliza DMA.** Mantiene alimentadas las FIFOs sin bloquear la CPU.
+3. **Divide funciones entre máquinas.** Un bloque puede generar reloj y otro manejar datos.
+4. **Depura con `pioasm`.** El SDK incluye herramientas para validar el programa antes de compilar.
+5. **Sincroniza con IRQ.** Usa interrupciones PIO para coordinar eventos con el firmware principal.
+
+---
+
+## Recursos adicionales
+
+- Documentación oficial del **RP2040 Datasheet** (capítulo PIO).
+- Ejemplos del **Pico SDK** (`pio/`): UART, I²C, PWM mejorado, DVI.
+- Librerías comunitarias como **rp2040-pio-emulator** para pruebas en PC.
+
+Dominar PIO te permitirá extender la Raspberry Pi Pico más allá de sus periféricos estándar y construir soluciones de tiempo real personalizadas.

--- a/content/posts/microcontroladores/programar-pico-cpp/index.md
+++ b/content/posts/microcontroladores/programar-pico-cpp/index.md
@@ -1,0 +1,102 @@
+---
+title: "Programar la Pico en C++"
+date: 2024-03-16T13:30:00+02:00
+description: "Pasos para configurar el Pico SDK y compilar proyectos en C/C++ para la Raspberry Pi Pico y Pico 2 sin Arduino."
+menu:
+  sidebar:
+    name: Programar la Pico en C++
+    identifier: programar-pico-cpp
+    parent: microcontroladores
+    weight: 4
+hero: images/programar-pico-cpp-cover.jpg
+tags:
+- Raspberry Pi Pico
+- C++
+- Pico SDK
+- Herramientas de desarrollo
+categories:
+- Microcontroladores
+- Software
+---
+
+Programar la Raspberry Pi Pico directamente en C/C++ ofrece máximo control sobre el hardware y mejor desempeño que las capas de compatibilidad Arduino. Estos son los pasos clave para configurar el entorno oficial **Pico SDK** en Windows, Linux o macOS.
+
+---
+
+## Requisitos previos
+
+- **Toolchain Arm GCC** (`arm-none-eabi-gcc` y `newlib`).
+- **CMake ≥ 3.13** y **Ninja** o Make.
+- **Python 3** para scripts auxiliares.
+- **Git** para clonar el SDK y submódulos.
+
+En Windows se recomienda usar **WSL** o el instalador oficial que empaqueta todas las dependencias.
+
+---
+
+## Instalación del Pico SDK
+
+```bash
+mkdir -p ~/pico && cd ~/pico
+git clone -b master https://github.com/raspberrypi/pico-sdk.git
+cd pico-sdk
+git submodule update --init
+export PICO_SDK_PATH=$PWD
+```
+
+Añade la variable `PICO_SDK_PATH` a tu `.bashrc` o script de entorno.
+
+Para la **Pico 2 (RP2350)** habilita el flag `PICO_PLATFORM=rp2350` o usa la rama `sdk-2.0` que soporta el nuevo silicio.
+
+---
+
+## Crear un proyecto base
+
+```bash
+cd ~/pico
+git clone https://github.com/raspberrypi/pico-examples.git
+cd pico-examples/blink
+mkdir build && cd build
+cmake -DPICO_BOARD=pico_w ..
+ninja
+```
+
+Generarás archivos `.uf2` y `.elf`. Copia el `.uf2` a la unidad montada cuando la Pico esté en modo BOOTSEL.
+
+---
+
+## Estructura recomendada
+
+```
+my-project/
+├── CMakeLists.txt
+├── cmake/
+│   └── pico_sdk_import.cmake
+├── include/
+├── src/
+│   └── main.cpp
+└── build/
+```
+
+- `pico_sdk_import.cmake` apunta al SDK sin necesidad de variables globales.
+- Define **targets** específicos (`pico_add_extra_outputs`, `pico_enable_stdio_usb`).
+
+---
+
+## Depuración y pruebas
+
+1. Conecta un **debug probe** (Picoprobe, CMSIS-DAP) al puerto SWD.
+2. Usa **OpenOCD** con el archivo `interface/picoprobe.cfg` y `target/rp2040.cfg`.
+3. Inicia **gdb-multiarch** o `arm-none-eabi-gdb` para setear breakpoints y ver registros.
+4. Aprovecha **pico_unit** o frameworks como **Unity** para pruebas unitarias en host.
+
+---
+
+## Buenas prácticas
+
+- Habilita **std::span**, `-fno-exceptions` y LTO para reducir tamaño si no necesitas RTTI.
+- Documenta la versión del SDK en `cmake/pico_sdk_import.cmake`.
+- Crea **targets separados** para Pico y Pico W con diferentes opciones de Wi-Fi/Bluetooth.
+- Automatiza builds con GitHub Actions usando contenedores oficiales `raspberrypi/pico-sdk`.
+
+Con esta configuración tendrás un flujo profesional para desarrollar en C/C++ sobre la Raspberry Pi Pico y sus variantes sin depender de Arduino.

--- a/content/posts/microcontroladores/raspberry-pi-pico/index.md
+++ b/content/posts/microcontroladores/raspberry-pi-pico/index.md
@@ -1,0 +1,70 @@
+---
+title: "Raspberry Pi Pico"
+date: 2024-03-16T11:00:00+02:00
+description: "Características clave del RP2040, periféricos destacados y usos típicos de la Raspberry Pi Pico."
+menu:
+  sidebar:
+    name: Raspberry Pi Pico
+    identifier: raspberry-pi-pico
+    parent: microcontroladores
+    weight: 1
+hero: images/raspberry-pi-pico-cover.jpg
+tags:
+- Raspberry Pi Pico
+- RP2040
+- Microcontroladores
+- Prototipado
+categories:
+- Microcontroladores
+- Hardware
+---
+
+La **Raspberry Pi Pico** es la primera placa oficial basada en el microcontrolador RP2040 de la Fundación Raspberry Pi. Combina precio contenido, doble núcleo Cortex-M0+ y periféricos flexibles que la convierten en una plataforma ideal para proyectos embebidos y de enseñanza.
+
+---
+
+## Especificaciones esenciales
+
+- **Microcontrolador:** RP2040 con dos núcleos Arm Cortex-M0+ a 133 MHz (overclock estable hasta ~250 MHz).
+- **Memoria:** 264 KB de SRAM repartida en bancos y hasta 16 MB de flash externa QSPI.
+- **Periféricos:** 30 GPIO, 2×USB 1.1, 2×UART, 2×I²C, 2×SPI, 16 canales PWM, ADC de 12 bits, 8 máquinas PIO.
+- **Alimentación:** 1,8–5,5 V, regulador buck-boost integrado.
+- **Formatos:** Pico estándar, Pico W (Wi-Fi), Pico H (headers soldados) y módulos embebibles.
+
+---
+
+## Fortalezas del RP2040
+
+1. **PIO (Programmable I/O).** Motores de estado que permiten implementar protocolos personalizados a nivel de hardware.
+2. **Doble núcleo.** Separar tareas críticas en un core mientras el otro maneja lógica de alto nivel.
+3. **Bajo costo y disponibilidad.** La placa base ronda los 4 USD.
+4. **Comunidad y documentación amplia.** SDK en C/C++, MicroPython, CircuitPython y ejemplos oficiales.
+
+---
+
+## Casos de uso recomendados
+
+- **Controladores de robots educativos** gracias a su PWM abundante y soporte MicroPython.
+- **Interfaces personalizadas** (DVI, VGA, audio PDM) mediante PIO.
+- **IoT económico** con el modelo Pico W y su módulo Wi-Fi CYW43439.
+- **Instrumentos de laboratorio DIY** como generadores de señales y analizadores lógicos.
+
+---
+
+## Ecosistema de software
+
+- **Pico SDK (C/C++).** Acceso directo al hardware con CMake, soporte para FreeRTOS y drivers oficiales.
+- **MicroPython y CircuitPython.** Repl inmediato, ideal para iterar rápido.
+- **TinyUSB.** Implementaciones de dispositivos USB (CDC, HID, MIDI) listas para usar.
+- **Bibliotecas de terceros.** Drivers para pantallas, sensores y motores mantenidos por la comunidad.
+
+---
+
+## Consejos para proyectos
+
+1. Usa el **SMPS integrado** (VSYS) para alimentar sensores de 3,3 V y evita exceder 300 mA.
+2. Aprovecha el **debug por SWD** expuesto en los pads debajo de la placa.
+3. Para aplicaciones críticas, añade **flash externa de calidad** y watchdog habilitado.
+4. Documenta la versión del SDK en tu repositorio para reproducibilidad.
+
+Con estos puntos tendrás un panorama claro de lo que ofrece la Raspberry Pi Pico y podrás decidir cuándo utilizarla frente a otras opciones.

--- a/content/posts/robotica/_index.en.md
+++ b/content/posts/robotica/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: Robotics
+menu:
+  sidebar:
+    name: Robotics
+    identifier: robotics
+    weight: 5
+---

--- a/content/posts/robotica/_index.md
+++ b/content/posts/robotica/_index.md
@@ -1,0 +1,8 @@
+---
+title: Robótica
+menu:
+  sidebar:
+    name: Robótica
+    identifier: robotica
+    weight: 5
+---

--- a/content/posts/robotica/herramientas-ros2/index.md
+++ b/content/posts/robotica/herramientas-ros2/index.md
@@ -1,0 +1,84 @@
+---
+title: "Herramientas indispensables para ROS 2"
+date: 2024-03-16T12:00:00+02:00
+description: "Panorama de utilidades como ros2 topic, RViz, PlotJuggler y Foxglove para depurar y visualizar sistemas ROS 2."
+menu:
+  sidebar:
+    name: Herramientas ROS 2
+    identifier: herramientas-ros2
+    parent: robotica
+    weight: 1
+hero: images/herramientas-ros2-cover.jpg
+tags:
+- ROS 2
+- Robótica
+- Herramientas de depuración
+- Visualización de datos
+categories:
+- Robótica
+- Software
+---
+
+ROS 2 ofrece múltiples utilidades para monitorear tópicos, analizar logs y depurar sistemas distribuidos. Conocer las herramientas correctas acelera el desarrollo y evita perder horas persiguiendo bugs.
+
+---
+
+## Línea de comandos
+
+- **`ros2 topic`**: inspecciona publicadores, suscriptores y contenido en tiempo real (`ros2 topic echo`, `ros2 topic hz`). Útil para validar tipos de mensajes y latencias.
+- **`ros2 node`**: lista nodos activos, interfaces y parámetros expuestos.
+- **`ros2 param`**: permite leer/escribir parámetros dinámicos, ideal para ajustar PIDs o constantes sin recompilar.
+- **`ros2 bag`**: registra y reproduce mensajes DDS para depuración offline o análisis de regresiones.
+
+---
+
+## Visualización 3D con RViz
+
+RViz es la navaja suiza para visualizar mapas, nubes de puntos y frames TF.
+
+1. Crea **displays** para láser, cámaras, odometría y TF.
+2. Usa **Fixed Frame** coherente (por ejemplo `map` o `base_link`).
+3. Configura **markers** y **interactive markers** para depurar planes y acciones.
+4. Exporta configuraciones en `.rviz` para compartir con tu equipo.
+
+---
+
+## PlotJuggler
+
+Herramienta especializada en series de tiempo.
+
+- Conecta vía plugin ROS 2 para recibir tópicos directamente.
+- Crea **dashboards** con filtros y expresiones matemáticas.
+- Exporta a CSV o ROS bag para análisis posterior.
+- Ideal para ajustar controladores PID, monitorear corrientes y tensiones en robots móviles.
+
+---
+
+## RQt y paneles personalizados
+
+RQt (Qt + plugins ROS) permite construir interfaces gráficas rápidas:
+
+- **rqt_graph** para visualizar la topología de nodos.
+- **rqt_console** y **rqt_logger_level** para filtrar logs.
+- **rqt_reconfigure** (con `ros2_control` o `dynamic_reconfigure`) para ajustar parámetros en vivo.
+
+---
+
+## Foxglove Studio
+
+Una opción moderna multiplataforma que se conecta mediante Foxglove Bridge o rosbridge.
+
+- Visualiza tópicos 2D/3D, dashboards y mapas en el navegador.
+- Graba **Foxglove Data Platform** o reproduce ROS bag.
+- Integra anotaciones colaborativas y métricas de rendimiento.
+
+---
+
+## Buenas prácticas
+
+1. **Mantén plantillas de configuración.** Almacena layouts de RViz, PlotJuggler y Foxglove en tu repositorio.
+2. **Automatiza capturas.** Usa `ros2 bag` en pipelines CI para comparar ejecuciones.
+3. **Unifica namespaces.** Consistencia en nombres simplifica filtros y scripts.
+4. **Documenta flujos de trabajo.** Define qué herramienta usar en cada etapa: bring-up, calibración, pruebas en campo.
+
+Dominar estas utilidades te permitirá diagnosticar robots ROS 2 con rapidez y trabajar de forma colaborativa con tu equipo.

--- a/content/posts/sensores/_index.en.md
+++ b/content/posts/sensores/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: Sensors
+menu:
+  sidebar:
+    name: Sensors
+    identifier: sensors
+    weight: 4
+---

--- a/content/posts/sensores/_index.md
+++ b/content/posts/sensores/_index.md
@@ -1,0 +1,8 @@
+---
+title: Sensores
+menu:
+  sidebar:
+    name: Sensores
+    identifier: sensores
+    weight: 4
+---

--- a/content/posts/sensores/encoder/index.md
+++ b/content/posts/sensores/encoder/index.md
@@ -1,0 +1,74 @@
+---
+title: "Encoders"
+date: 2024-03-16T14:00:00+02:00
+description: "Principios de funcionamiento de los encoders rotativos y lineales, tipos y criterios de selección."
+menu:
+  sidebar:
+    name: Encoders
+    identifier: encoders
+    parent: sensores
+    weight: 1
+hero: images/encoders-cover.jpg
+tags:
+- Encoders
+- Control de movimiento
+- Sensores
+- Automatización
+categories:
+- Sensores
+- Control de movimiento
+math: true
+---
+
+Los **encoders** convierten movimiento en señales eléctricas para medir posición, velocidad o dirección. Son fundamentales en robótica, CNC y servo sistemas.
+
+---
+
+## Clasificación principal
+
+| Tipo | Principio | Resolución típica | Ventajas | Desventajas |
+| --- | --- | --- | --- | --- |
+| Incremental óptico | Interrupción de luz LED-fotorreceptor | 100–10.000 PPR | Alta precisión, señales cuadratura. | Sensibles al polvo, requieren referencia absoluta externa. |
+| Incremental magnético | Sensor Hall/magnetorresistivo | 32–2048 PPR | Robustos, toleran suciedad. | Menor precisión angular. |
+| Absoluto óptico | Código Gray en disco | 10–20 bits | Posición única sin homing. | Costosos, tamaño mayor. |
+| Absoluto magnético | Sensor Hall 3D + ASIC | 12–16 bits | Compactos, soportan vibración. | Requieren calibración precisa del imán. |
+| Lineales (regla óptica/magnética) | Codificación incremental o absoluta | 1–10 µm | CNC y metrología. | Instalación compleja. |
+
+---
+
+## Señales y conexiones
+
+- **Cuadratura A/B**: permite detectar dirección y multiplicar la resolución x4 con flancos.
+- **Index (Z)**: referencia una vuelta completa.
+- **Salida push-pull u open-collector**: elige drivers compatibles con tu PLC o microcontrolador.
+- **Interfaces absolutas**: SSI, BiSS-C, CANopen, EtherCAT, I²C/SPI en modelos compactos.
+
+---
+
+## Seleccionar un encoder
+
+1. **Resolución necesaria**: determina pulsos por revolución (PPR) o bits. Considera reducción mecánica y microstepping.
+2. **Velocidad máxima**: verifica frecuencia de salida \(f = \text{PPR} \times \text{RPM} / 60\) para dimensionar entradas.
+3. **Ambiente**: polvo, vibración, temperatura. Escoge IP adecuado y sellado.
+4. **Montaje**: eje sólido, hueco, sin rodamientos (kit encoder), acople flexible.
+5. **Protocolo**: compatibilidad con controladores existentes.
+
+---
+
+## Aplicaciones típicas
+
+- **Servomotores AC/DC** con control de posición.
+- **Robots móviles** para odometría diferencial.
+- **Impresoras 3D y CNC** para realimentar husillos o camas.
+- **Instrumentación** en metrología y mesas de inspección.
+
+---
+
+## Buenas prácticas
+
+1. **Alinea mecánicamente** el eje y usa acoples flexibles para evitar cargas radiales.
+2. **Protege el cableado** con pares trenzados y blindaje conectado a tierra por un extremo.
+3. **Implementa homing seguro** aun con encoders absolutos para validar límites físicos.
+4. **Filtra ruido** con entradas diferenciales (RS-422) y filtros digitales en firmware.
+
+Comprender estas variables te permitirá seleccionar el encoder adecuado y garantizar lecturas confiables en tus sistemas de control de movimiento.

--- a/content/posts/sensores/lidar/index.md
+++ b/content/posts/sensores/lidar/index.md
@@ -1,0 +1,74 @@
+---
+title: "Lidar"
+date: 2024-03-16T15:30:00+02:00
+description: "Conceptos fundamentales del Lidar, tecnologías de escaneo y criterios para elegir un modelo para robótica."
+menu:
+  sidebar:
+    name: Lidar
+    identifier: lidar
+    parent: sensores
+    weight: 4
+hero: images/lidar-cover.jpg
+tags:
+- Lidar
+- Robótica
+- SLAM
+- Sensores de distancia
+categories:
+- Sensores
+- Robótica
+---
+
+Los sistemas **Lidar (Light Detection and Ranging)** miden distancias con láser y generan mapas de alta resolución. Son esenciales en SLAM, vehículos autónomos e inspección industrial.
+
+---
+
+## Tecnologías principales
+
+1. **Lidar rotativo 2D:** un láser gira 360° en un plano horizontal. Ejemplos: RPLidar A2, Hokuyo UST.
+2. **Lidar rotativo 3D:** varias líneas láser (Velodyne, Ouster) o inclinación mecánica para generar nubes 3D.
+3. **Solid-state (MEMS, flash, FMCW):** sin partes móviles, menor tamaño y costo creciente en automoción.
+4. **Time-of-Flight directo vs FMCW:** ToF mide tiempo, FMCW mide frecuencia y obtiene velocidad relativa.
+
+---
+
+## Parámetros clave
+
+- **Alcance:** distancia máxima efectiva para objetos con reflectividad estándar.
+- **Frecuencia de escaneo:** Hz o RPM; determina cuántos datos por segundo.
+- **Resolución angular:** separación entre mediciones; influye en densidad de nube.
+- **Campo de visión (FoV):** horizontal y vertical.
+- **Precisión y repetibilidad:** error absoluto y ruido entre mediciones.
+- **Clase láser:** seguridad ocular (Clase 1 preferida para interiores).
+
+---
+
+## Comparativa rápida
+
+| Modelo | Tipo | Alcance | Frecuencia | Nota destacada |
+| --- | --- | --- | --- | --- |
+| RPLidar A1 | 2D | 12 m | 5–10 Hz | Económico para hobby, sin protección polvo. |
+| Slamtec S1 | 2D | 40 m | 10–20 Hz | IP65, lidar doble motor. |
+| Hokuyo UST-10LX | 2D | 10 m | 40 Hz | Industrial, interfaz Ethernet. |
+| Ouster OS1 | 3D solid-state | 120 m | 10–20 Hz | Alta densidad, APIs ROS listas. |
+| Livox MID-360 | 3D no rotativo | 70 m | 20 Hz | Escaneo no repetitivo con fusión temporal. |
+
+---
+
+## Integración en robots
+
+1. **Montaje rígido** y calibración de transformaciones TF para ROS/ROS 2.
+2. **Sincronización temporal** con IMU o cámaras para SLAM preciso.
+3. **Filtrado de ruido** (VoxelGrid, StatisticalOutlierRemoval) antes de alimentar algoritmos.
+4. **Gestión de energía**: algunos modelos consumen >10 W, planifica la fuente.
+
+---
+
+## Buenas prácticas
+
+- Mantén **superficies limpias**; polvo o insectos generan falsos positivos.
+- Usa **zonas de exclusión** en software para ignorar partes del robot.
+- Configura **firmware y drivers oficiales** para aprovechar actualizaciones de calibración.
+- Considera **climatización** si operas en exterior (calentadores, deshumidificadores).
+
+Con estos criterios podrás elegir e integrar un Lidar acorde a tus necesidades de navegación y percepción.

--- a/content/posts/sensores/sensores-hall/index.md
+++ b/content/posts/sensores/sensores-hall/index.md
@@ -1,0 +1,68 @@
+---
+title: "Sensores Hall"
+date: 2024-03-16T14:30:00+02:00
+description: "Funcionamiento de los sensores de efecto Hall, configuraciones lineales y digitales y aplicaciones en motores y encoders."
+menu:
+  sidebar:
+    name: Sensores Hall
+    identifier: sensores-hall
+    parent: sensores
+    weight: 2
+hero: images/sensores-hall-cover.jpg
+tags:
+- Sensores Hall
+- Motores
+- Encoders
+- Magnetismo
+categories:
+- Sensores
+- Control de movimiento
+math: true
+---
+
+El **efecto Hall** describe la diferencia de potencial que aparece cuando un conductor con corriente atraviesa un campo magnético. Los sensores Hall aprovechan este fenómeno para medir posición, velocidad o corriente sin contacto mecánico.
+
+---
+
+## Tipos principales
+
+1. **Hall digital tipo interruptor:** salida on/off con histéresis. Usados en detección de proximidad, finales de carrera o conmutación de motores BLDC.
+2. **Hall latch (bipolares):** cambian de estado al detectar polos norte/sur, ideales para codificadores magnéticos.
+3. **Hall lineales:** entregan una tensión proporcional al campo \(V_{out} = V_{ref} + S \cdot B\), donde \(S\) es la sensibilidad.
+4. **Sensores Hall de corriente:** combinan un conductor y núcleo magnético para medir corriente en bus.
+
+---
+
+## Aplicaciones en motores
+
+- **Conmutación BLDC:** tres sensores ubicados a 120° eléctricos generan la secuencia de activación de fases.
+- **Detección de rotor en motores paso a paso híbridos** cuando se requiere feedback adicional.
+- **Protección contra sobrecorriente** en drivers mediante Hall lineales integrados.
+
+---
+
+## Integración en encoders
+
+- Encoders magnéticos como **AS5048**, **MA730** o **TLE5012** usan un imán diametral y sensores Hall 2D/3D.
+- La resolución depende del ASIC (hasta 14 bits) y la alineación axial del imán.
+- Proporcionan interfaces SPI, I²C, PWM o ABI (A/B/Z) compatibles con sistemas existentes.
+
+---
+
+## Diseño con sensores Hall
+
+1. **Colocación del imán:** asegura una distancia uniforme. Usa imanes diametrales o multipolares según la aplicación.
+2. **Blindaje y ruido:** filtra con capacitores y protege contra campos externos fuertes.
+3. **Alimentación estable:** muchos sensores usan referencias internas de 2,5 V; añade bypass de 100 nF + 1 µF.
+4. **Calibración:** aplica offsets y escalas vía firmware para corregir tolerancias.
+
+---
+
+## Selección del sensor
+
+- **Rango de campo:** elige un dispositivo cuyo rango abarque tu campo máximo sin saturación.
+- **Sensibilidad y ruido:** evalúa densidad espectral de ruido para mediciones precisas.
+- **Temperatura:** para aplicaciones automotrices busca rangos -40 a 150 °C.
+- **Salida:** digital open-drain, push-pull, analógica ratiométrica o PWM.
+
+Comprender estas variables te permitirá integrar sensores Hall de forma confiable en sistemas de motores, encoders y medición de corriente.

--- a/content/posts/sensores/sensores-ultrasonicos/index.md
+++ b/content/posts/sensores/sensores-ultrasonicos/index.md
@@ -1,0 +1,80 @@
+---
+title: "Sensores ultrasónicos"
+date: 2024-03-16T15:00:00+02:00
+description: "Principios de los sensores ultrasónicos de distancia, consideraciones de diseño y estrategias de filtrado."
+menu:
+  sidebar:
+    name: Sensores ultrasónicos
+    identifier: sensores-ultrasonicos
+    parent: sensores
+    weight: 3
+hero: images/sensores-ultrasonicos-cover.jpg
+tags:
+- Ultrasónico
+- Distancia
+- Robótica móvil
+- Sensores
+categories:
+- Sensores
+- Robótica
+math: true
+---
+
+Los **sensores ultrasónicos** miden distancia calculando el tiempo que tarda un pulso acústico en viajar y regresar desde un obstáculo. Son económicos y útiles en robótica móvil, medición de nivel y domótica.
+
+---
+
+## Componentes clave
+
+- **Transductor emisor/receptor** piezoeléctrico (~40 kHz).
+- **Driver** que genera burst de alta tensión (80–120 Vpp en modelos industriales).
+- **Detector de eco** con amplificación logarítmica.
+- **Controlador** que mide el tiempo de vuelo (ToF) y entrega una lectura digital o analógica.
+
+La distancia se calcula como:
+
+\[
+d = \frac{v_{sonido} \cdot t_{eco}}{2}
+\]
+
+donde \(v_{sonido}\) ≈ 343 m/s a 20 °C.
+
+---
+
+## Módulos populares
+
+| Modelo | Interfaz | Rango típico | Precisión | Notas |
+| --- | --- | --- | --- | --- |
+| HC-SR04 | Trigger/Echo (5 V) | 2–400 cm | ±3 mm | Necesita conversión de nivel para 3,3 V. |
+| JSN-SR04T | Trigger/Echo, impermeable | 25–600 cm | ±20 mm | Sensor remoto IP66, ideal exterior. |
+| MaxBotix MB1240 | PWM, analógica, serie | 20–765 cm | ±2,5 cm | Auto-calibración y filtrado de ruido. |
+| Ultrasónicos industriales | 4–20 mA, IO-Link | >8 m | ±1 % | Resisten polvo, alta tensión de excitación. |
+
+---
+
+## Consideraciones de diseño
+
+1. **Ángulo de haz:** típicamente 15°. Objetos pequeños o inclinados pueden no reflejar suficiente energía.
+2. **Temperatura y humedad:** afectan la velocidad del sonido. Compensa con sensores de temperatura o tablas.
+3. **Ruido eléctrico:** usa capacitores de desacoplo y layout corto entre driver y transductor.
+4. **Interferencias cruzadas:** programa ventanas de escucha y IDs si múltiples sensores operan simultáneamente.
+
+---
+
+## Filtrado y procesamiento
+
+- **Promedios móviles** para suavizar lecturas.
+- **Filtros mediana** para eliminar ecos falsos.
+- **Ventanas de aceptación** basadas en velocidad máxima esperada para descartar saltos.
+- **Fusión sensorial** con encoders, IMU o lidar para mejorar precisión.
+
+---
+
+## Aplicaciones
+
+- Evitar colisiones en robots y drones terrestres.
+- Medir nivel en tanques de agua o granos.
+- Detectar presencia en puertas automáticas.
+- Controlar estaciones de estacionamiento y basureros inteligentes.
+
+Seleccionar el módulo adecuado y diseñar el entorno eléctrico y mecánico correctamente garantizará lecturas estables en tus proyectos ultrasónicos.

--- a/content/posts/software/_index.en.md
+++ b/content/posts/software/_index.en.md
@@ -1,0 +1,8 @@
+---
+title: Software
+menu:
+  sidebar:
+    name: Software
+    identifier: software-en
+    weight: 6
+---

--- a/content/posts/software/_index.md
+++ b/content/posts/software/_index.md
@@ -1,0 +1,8 @@
+---
+title: Software
+menu:
+  sidebar:
+    name: Software
+    identifier: software
+    weight: 6
+---

--- a/content/posts/software/whisper-python/index.md
+++ b/content/posts/software/whisper-python/index.md
@@ -1,0 +1,81 @@
+---
+title: "Transcribir audio con Whisper"
+date: 2024-03-16T16:00:00+02:00
+description: "Guía paso a paso para instalar OpenAI Whisper y convertir audio a texto con Python."
+menu:
+  sidebar:
+    name: Transcribir audio con Whisper
+    identifier: whisper-python
+    parent: software
+    weight: 1
+hero: images/whisper-python-cover.jpg
+tags:
+- Whisper
+- Python
+- Transcripción
+- IA
+categories:
+- Software
+- Inteligencia artificial
+---
+
+**Whisper** es un modelo de reconocimiento de voz multilingüe de código abierto creado por OpenAI. Permite transcribir audio a texto con alta precisión sin depender de servicios en la nube.
+
+---
+
+## Requisitos
+
+- Python 3.8 o superior.
+- Pip y virtualenv.
+- FFmpeg instalado en el sistema (necesario para convertir formatos de audio).
+- GPU opcional (CUDA) para acelerar inferencias con modelos grandes.
+
+Instala FFmpeg en Linux con `sudo apt install ffmpeg` o usa los binarios oficiales en Windows/macOS.
+
+---
+
+## Instalación
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # En Windows: .venv\Scripts\activate
+pip install --upgrade pip
+pip install openai-whisper ffmpeg-python torch torchvision torchaudio
+```
+
+Si cuentas con GPU Nvidia, instala la versión de PyTorch compatible con tu versión de CUDA desde `https://pytorch.org/get-started/locally/` antes de `openai-whisper`.
+
+---
+
+## Transcripción básica
+
+```python
+import whisper
+
+model = whisper.load_model("small")
+result = model.transcribe("entrevista.wav", language="es")
+print(result["text"])
+```
+
+El parámetro `language` acelera la detección. Usa modelos `tiny`, `base`, `small`, `medium` o `large` según recursos y precisión.
+
+---
+
+## Optimización y trucos
+
+1. **Segmenta audios largos** para evitar agotar memoria (`whisper.utils.get_writer`).
+2. **Activa `fp16=False`** si corres en CPU o GPUs sin soporte FP16.
+3. **Guarda subtítulos** usando `writer = whisper.utils.get_writer("srt", "./salidas")`.
+4. **Limpia ruido** previamente con herramientas como `pydub` o `noisereduce` para mejorar resultados.
+5. **Traducción**: `model.transcribe(..., task="translate")` genera texto en inglés desde cualquier idioma.
+
+---
+
+## Integración en pipelines
+
+- Automatiza carga desde S3, GCS o almacenamiento local.
+- Envía resultados a bases de datos o motores de búsqueda (Elastic, Pinecone).
+- Expone un microservicio FastAPI para procesar cargas de usuarios.
+- Combina con diarización (Pyannote) para identificar hablantes.
+
+Con estos pasos tendrás una solución reproducible para transcribir audio a texto usando Whisper y Python.


### PR DESCRIPTION
## Summary
- add new top-level sections for microcontroladores, comunicaciones, sensores, robótica, software y hardware digital in the sidebar menu
- publish 20 technical posts covering electrónica (pull-ups, baterías, protección, op-amps, capacitancia), microcontroladores (Pico, ESP32, PIO, micro-ROS, expansores), sensores/robótica (encoders, Hall, ultrasonido, lidar, herramientas ROS 2) y comunicaciones/software (Meshtastic, MQTT, Whisper, FPGA)

## Testing
- `hugo -D` *(blocked by mise trust prompt in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4fe3f7558832d9e33c7b35f9c5ec2